### PR TITLE
support chunked OHTTP and P384

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,10 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         hpke:
-          - nss
           - rust-hpke
         rust:
-          - 1.63.0 # MSRV
+          - 1.75.0
           - stable
 
     steps:

--- a/bhttp/Cargo.toml
+++ b/bhttp/Cargo.toml
@@ -16,10 +16,13 @@ read-bhttp = []
 write-bhttp = []
 read-http = ["url"]
 write-http = []
+stream = []
 
 [dependencies]
 thiserror = "1"
 url = {version = "2", optional = true}
+tracing = "0.1"
+backtrace = "0.3"
 
 [dev-dependencies]
 hex = "0.4"

--- a/bhttp/src/err.rs
+++ b/bhttp/src/err.rs
@@ -15,12 +15,16 @@ pub enum Error {
     ExpectedResponse,
     #[error("a field contained an integer value that was out of range: {0}")]
     IntRange(#[from] std::num::TryFromIntError),
+    #[error("Invalid end of chunk. Expected zero-sized chunk")]
+    InvalidChunkEnd,
     #[error("the mode of the message was invalid")]
     InvalidMode,
     #[error("the status code of a response needs to be in 100..=599")]
     InvalidStatus,
     #[error("IO error {0}")]
     Io(#[from] std::io::Error),
+    #[error("Invalid uint")]
+    InvalidUint,
     #[error("a field or line was missing a necessary character 0x{0:x}")]
     Missing(u8),
     #[error("a URL was missing a key component")]
@@ -31,11 +35,15 @@ pub enum Error {
     ParseInt(#[from] std::num::ParseIntError),
     #[error("a field was truncated")]
     Truncated,
+    #[error("Unreachable")]
+    Unreachable,
     #[error("a message included the Upgrade field")]
     UpgradeUnsupported,
     #[error("a URL could not be parsed into components: {0}")]
     #[cfg(feature = "read-http")]
     UrlParse(#[from] url::ParseError),
+    #[error("Varint value too large")]
+    VariantTooLarge,
 }
 
 #[cfg(any(

--- a/bhttp/src/lib.rs
+++ b/bhttp/src/lib.rs
@@ -681,7 +681,9 @@ impl Message {
             }
             let mut buf = vec![0; count];
             r.borrow_mut().read_exact(&mut buf)?;
-            assert!(read_line(r)?.is_empty());
+            if !read_line(r)?.is_empty() {
+                return Err(Error::InvalidChunkEnd);
+            }
             content.append(&mut buf);
         }
     }
@@ -781,7 +783,9 @@ impl Message {
         let mode = match t {
             0 | 1 => Mode::KnownLength,
             2 | 3 => Mode::IndeterminateLength,
-            _ => return Err(Error::InvalidMode),
+            _ => {
+                return Err(Error::InvalidMode);
+            }
         };
 
         let mut control = ControlData::read_bhttp(request, r)?;

--- a/ohttp/Cargo.toml
+++ b/ohttp/Cargo.toml
@@ -28,7 +28,7 @@ byteorder = "1.4"
 chacha20poly1305 = {version = "0.8", optional = true}
 hex = "0.4"
 hkdf = {version = "0.11", optional = true}
-hpke = {version = "0.11.0", optional = true, default-features = false, features = ["std", "x25519"]}
+hpke = {version = "0.12.0", optional = true, default-features = false, features = ["std", "x25519", "p384"]}
 lazy_static = "1.4"
 log = {version = "0.4", default-features = false}
 rand = {version = "0.8", optional = true}
@@ -39,6 +39,13 @@ regex-automata = {version = "~0.3", optional = true}
 regex-syntax = {version = "~0.7", optional = true}
 sha2 = {version = "0.9", optional = true}
 thiserror = "1"
+futures-util = "0.3.30"
+futures = "0.3.30"
+bytes = "1.7.2"
+async-stream = "0.3.5"
+tokio = { version = "1.40.0", features = ["full"] }
+tracing = "0.1"
+backtrace = "0.3"
 
 [dependencies.hpke-pq]
 package = "hpke_pq"

--- a/ohttp/src/err.rs
+++ b/ohttp/src/err.rs
@@ -5,6 +5,8 @@ pub enum Error {
     #[cfg(feature = "rust-hpke")]
     #[error("a problem occurred with the AEAD")]
     Aead(#[from] aead::Error),
+    #[error("AEAD mode mismatch")]
+    AeadMode,
     #[cfg(feature = "nss")]
     #[error("a problem occurred during cryptographic processing: {0}")]
     Crypto(#[from] crate::nss::Error),
@@ -22,16 +24,24 @@ pub enum Error {
     InvalidKeyType,
     #[error("the wrong KEM was specified")]
     InvalidKem,
+    #[error("Invalid private key")]
+    InvalidPrivateKey,
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
     #[error("the key ID was invalid")]
     KeyId,
-    #[error("a field was truncated")]
-    Truncated,
-    #[error("the configuration was not supported")]
-    Unsupported,
+    #[error("Returned a different key ID from the one requested : {0} {1}")]
+    KeyIdMismatch(u8, u8),
+    #[error("Symmetric key is empty")]
+    SymmetricKeyEmpty,
     #[error("the configuration contained too many symmetric suites")]
     TooManySymmetricSuites,
+    #[error("a field was truncated")]
+    Truncated,
+    #[error("the two lengths are not equal : {0} {1}")]
+    UnequalLength(usize, usize),
+    #[error("the configuration was not supported")]
+    Unsupported,
 }
 
 impl From<std::num::TryFromIntError> for Error {

--- a/ohttp/src/hpke.rs
+++ b/ohttp/src/hpke.rs
@@ -31,6 +31,8 @@ macro_rules! convert_enum {
 
 convert_enum! {
 pub enum Kem {
+    P384Sha384 = 17,
+
     X25519Sha256 = 32,
 
     #[cfg(feature = "pq")]
@@ -42,6 +44,8 @@ impl Kem {
     #[must_use]
     pub fn n_enc(self) -> usize {
         match self {
+            Kem::P384Sha384 => 97,
+
             Kem::X25519Sha256 => 32,
 
             #[cfg(feature = "pq")]
@@ -52,6 +56,8 @@ impl Kem {
     #[must_use]
     pub fn n_pk(self) -> usize {
         match self {
+            Kem::P384Sha384 => 97,
+
             Kem::X25519Sha256 => 32,
 
             #[cfg(feature = "pq")]

--- a/ohttp/src/nss/aead.rs
+++ b/ohttp/src/nss/aead.rs
@@ -13,12 +13,12 @@ use crate::{
     err::{Error, Res},
     hpke::Aead as AeadId,
 };
-use log::trace;
 use std::{
     convert::{TryFrom, TryInto},
     mem,
     os::raw::c_int,
 };
+use tracing::trace;
 
 /// All the nonces are the same length.  Exploit that.
 pub const NONCE_LEN: usize = 12;
@@ -124,7 +124,9 @@ impl Aead {
     }
 
     pub fn seal(&mut self, aad: &[u8], pt: &[u8]) -> Res<Vec<u8>> {
-        assert_eq!(self.mode, Mode::Encrypt);
+        if self.mode != Mode::Encrypt {
+            return Err(Error::AeadMode);
+        }
         // A copy for the nonce generator to write into.  But we don't use the value.
         let mut nonce = self.nonce_base;
         // Ciphertext with enough space for the tag.
@@ -152,13 +154,20 @@ impl Aead {
             )
         })?;
         ct.truncate(usize::try_from(ct_len).unwrap());
-        debug_assert_eq!(ct.len(), pt.len());
+
+        ct_len = ct.len();
+        let pt_len = pt.len();
+        if ct_len != pt_len {
+            return Err(Error::UnequalLength(ct_len, pt_len));
+        }
         ct.append(&mut tag);
         Ok(ct)
     }
 
     pub fn open(&mut self, aad: &[u8], seq: SequenceNumber, ct: &[u8]) -> Res<Vec<u8>> {
-        assert_eq!(self.mode, Mode::Decrypt);
+        if self.mode != Mode::Decrypt {
+            return Err(Error::AeadMode);
+        }
         let mut nonce = self.nonce_base;
         for (i, n) in nonce.iter_mut().rev().take(COUNTER_LEN).enumerate() {
             *n ^= u8::try_from((seq >> (8 * i)) & 0xff).unwrap();
@@ -185,7 +194,9 @@ impl Aead {
             )
         })?;
         let len = usize::try_from(pt_len).unwrap();
-        debug_assert_eq!(len, pt_expected);
+        if len != pt_expected {
+            return Err(Error::UnequalLength(len, pt_expected));
+        }
         pt.truncate(len);
         Ok(pt)
     }

--- a/ohttp/src/nss/hkdf.rs
+++ b/ohttp/src/nss/hkdf.rs
@@ -10,8 +10,8 @@ use super::{
     },
 };
 use crate::err::Res;
-use log::trace;
 use std::{convert::TryFrom, os::raw::c_int, ptr::null_mut};
+use tracing::trace;
 
 #[derive(Clone, Copy)]
 pub enum KeyMechanism {

--- a/ohttp/src/nss/p11.rs
+++ b/ohttp/src/nss/p11.rs
@@ -109,7 +109,9 @@ impl Clone for PrivateKey {
     #[must_use]
     fn clone(&self) -> Self {
         let ptr = unsafe { sys::SECKEY_CopyPrivateKey(self.ptr) };
-        assert!(!ptr.is_null());
+        if ptr.is_null() {
+            return Error::unexpected;
+        }
         Self { ptr }
     }
 }
@@ -150,7 +152,9 @@ impl Clone for PublicKey {
     #[must_use]
     fn clone(&self) -> Self {
         let ptr = unsafe { sys::SECKEY_CopyPublicKey(self.ptr) };
-        assert!(!ptr.is_null());
+        if ptr.is_null() {
+            return Error::unexpected;
+        }
         Self { ptr }
     }
 }
@@ -198,7 +202,9 @@ impl Clone for SymKey {
     #[must_use]
     fn clone(&self) -> Self {
         let ptr = unsafe { PK11_ReferenceSymKey(self.ptr) };
-        assert!(!ptr.is_null());
+        if ptr.is_null() {
+            return Error::unexpected;
+        }
         Self { ptr }
     }
 }
@@ -274,7 +280,9 @@ impl Item {
     pub(crate) unsafe fn into_vec(self) -> Vec<u8> {
         let b = self.ptr.as_ref().unwrap();
         // Sanity check the type, as some types don't count bytes in `Item::len`.
-        assert_eq!(b.type_, SECItemType::siBuffer);
+        if b.type_ != SECItemType::siBuffer {
+            return Error::unexpected;
+        }
         let slc = std::slice::from_raw_parts(b.data, usize::try_from(b.len).unwrap());
         Vec::from(slc)
     }

--- a/ohttp/src/rh/hkdf.rs
+++ b/ohttp/src/rh/hkdf.rs
@@ -6,8 +6,8 @@ use crate::{
     hpke::{Aead, Kdf},
 };
 use hkdf::Hkdf as HkdfImpl;
-use log::trace;
 use sha2::{Sha256, Sha384, Sha512};
+use tracing::trace;
 
 #[derive(Clone, Copy)]
 pub enum KeyMechanism {

--- a/ohttp/src/rh/hpke.rs
+++ b/ohttp/src/rh/hpke.rs
@@ -11,9 +11,9 @@ use ::hpke as rust_hpke;
 use ::hpke_pq as rust_hpke;
 
 use rust_hpke::{
-    aead::{AeadCtxR, AeadCtxS, AeadTag, AesGcm128, ChaCha20Poly1305},
-    kdf::HkdfSha256,
-    kem::{Kem as KemTrait, X25519HkdfSha256},
+    aead::{AeadCtxR, AeadCtxS, AeadTag, AesGcm128, AesGcm256, ChaCha20Poly1305},
+    kdf::{HkdfSha256, HkdfSha384},
+    kem::{DhP384HkdfSha384, Kem as KemTrait, X25519HkdfSha256},
     setup_receiver, setup_sender, Deserializable, OpModeR, OpModeS, Serializable,
 };
 
@@ -21,8 +21,8 @@ use rust_hpke::{
 use rust_hpke::kem::X25519Kyber768Draft00;
 
 use ::rand::thread_rng;
-use log::trace;
 use std::ops::Deref;
+use tracing::trace;
 
 /// Configuration for `Hpke`.
 #[derive(Clone, Copy)]
@@ -51,7 +51,11 @@ impl Config {
 
     pub fn supported(self) -> bool {
         // TODO support more options
-        self.kdf == Kdf::HkdfSha256 && matches!(self.aead, Aead::Aes128Gcm | Aead::ChaCha20Poly1305)
+        matches!(self.kdf, Kdf::HkdfSha256 | Kdf::HkdfSha384)
+            && matches!(
+                self.aead,
+                Aead::Aes128Gcm | Aead::Aes256Gcm | Aead::ChaCha20Poly1305
+            )
     }
 }
 
@@ -70,6 +74,8 @@ impl Default for Config {
 pub enum PublicKey {
     X25519(<X25519HkdfSha256 as KemTrait>::PublicKey),
 
+    P384(<DhP384HkdfSha384 as KemTrait>::PublicKey),
+
     #[cfg(feature = "pq")]
     X25519Kyber768Draft00(<X25519Kyber768Draft00 as KemTrait>::PublicKey),
 }
@@ -78,6 +84,8 @@ impl PublicKey {
     #[allow(clippy::unnecessary_wraps)]
     pub fn key_data(&self) -> Res<Vec<u8>> {
         Ok(match self {
+            Self::P384(k) => Vec::from(k.to_bytes().as_slice()),
+
             Self::X25519(k) => Vec::from(k.to_bytes().as_slice()),
 
             #[cfg(feature = "pq")]
@@ -99,8 +107,8 @@ impl std::fmt::Debug for PublicKey {
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 pub enum PrivateKey {
+    P384(<DhP384HkdfSha384 as KemTrait>::PrivateKey),
     X25519(<X25519HkdfSha256 as KemTrait>::PrivateKey),
-
     #[cfg(feature = "pq")]
     X25519Kyber768Draft00(<X25519Kyber768Draft00 as KemTrait>::PrivateKey),
 }
@@ -109,6 +117,7 @@ impl PrivateKey {
     #[allow(clippy::unnecessary_wraps)]
     pub fn key_data(&self) -> Res<Vec<u8>> {
         Ok(match self {
+            Self::P384(k) => Vec::from(k.to_bytes().as_slice()),
             Self::X25519(k) => Vec::from(k.to_bytes().as_slice()),
 
             #[cfg(feature = "pq")]
@@ -134,6 +143,11 @@ enum SenderContextX25519HkdfSha256HkdfSha256 {
     ChaCha20Poly1305(Box<AeadCtxS<ChaCha20Poly1305, HkdfSha256, X25519HkdfSha256>>),
 }
 
+enum SenderContextDhP384HkdfSha384HkdfSha384 {
+    AesGcm128(Box<AeadCtxS<AesGcm128, HkdfSha384, DhP384HkdfSha384>>),
+    AesGcm256(Box<AeadCtxS<AesGcm256, HkdfSha384, DhP384HkdfSha384>>),
+}
+
 #[cfg(feature = "pq")]
 enum SenderContextX25519Kyber768Draft00HkdfSha256 {
     AesGcm128(Box<AeadCtxS<AesGcm128, HkdfSha256, X25519Kyber768Draft00>>),
@@ -143,6 +157,10 @@ enum SenderContextX25519HkdfSha256 {
     HkdfSha256(SenderContextX25519HkdfSha256HkdfSha256),
 }
 
+enum SenderContextDhP384HkdfSha384 {
+    HkdfSha384(SenderContextDhP384HkdfSha384HkdfSha384),
+}
+
 #[cfg(feature = "pq")]
 enum SenderContextX25519Kyber768Draft00 {
     HkdfSha256(SenderContextX25519Kyber768Draft00HkdfSha256),
@@ -150,6 +168,8 @@ enum SenderContextX25519Kyber768Draft00 {
 
 enum SenderContext {
     X25519HkdfSha256(SenderContextX25519HkdfSha256),
+
+    DhP384HkdfSha384(SenderContextDhP384HkdfSha384),
 
     #[cfg(feature = "pq")]
     X25519Kyber768Draft00(SenderContextX25519Kyber768Draft00),
@@ -170,7 +190,18 @@ impl SenderContext {
                 let tag = context.seal_in_place_detached(plaintext, aad)?;
                 Vec::from(tag.to_bytes().as_slice())
             }
-
+            Self::DhP384HkdfSha384(SenderContextDhP384HkdfSha384::HkdfSha384(
+                SenderContextDhP384HkdfSha384HkdfSha384::AesGcm128(context),
+            )) => {
+                let tag = context.seal_in_place_detached(plaintext, aad)?;
+                Vec::from(tag.to_bytes().as_slice())
+            }
+            Self::DhP384HkdfSha384(SenderContextDhP384HkdfSha384::HkdfSha384(
+                SenderContextDhP384HkdfSha384HkdfSha384::AesGcm256(context),
+            )) => {
+                let tag = context.seal_in_place_detached(plaintext, aad)?;
+                Vec::from(tag.to_bytes().as_slice())
+            }
             #[cfg(feature = "pq")]
             Self::X25519Kyber768Draft00(SenderContextX25519Kyber768Draft00::HkdfSha256(
                 SenderContextX25519Kyber768Draft00HkdfSha256::AesGcm128(context),
@@ -193,7 +224,16 @@ impl SenderContext {
             )) => {
                 context.export(info, out_buf)?;
             }
-
+            Self::DhP384HkdfSha384(SenderContextDhP384HkdfSha384::HkdfSha384(
+                SenderContextDhP384HkdfSha384HkdfSha384::AesGcm128(context),
+            )) => {
+                context.export(info, out_buf)?;
+            }
+            Self::DhP384HkdfSha384(SenderContextDhP384HkdfSha384::HkdfSha384(
+                SenderContextDhP384HkdfSha384HkdfSha384::AesGcm256(context),
+            )) => {
+                context.export(info, out_buf)?;
+            }
             #[cfg(feature = "pq")]
             Self::X25519Kyber768Draft00(SenderContextX25519Kyber768Draft00::HkdfSha256(
                 SenderContextX25519Kyber768Draft00HkdfSha256::AesGcm128(context),
@@ -277,7 +317,24 @@ impl HpkeS {
                 SenderContextX25519HkdfSha256::HkdfSha256,
                 SenderContextX25519HkdfSha256HkdfSha256::ChaCha20Poly1305,
             },
-
+            {
+                Kem::P384Sha384 => DhP384HkdfSha384,
+                Kdf::HkdfSha384 => HkdfSha384,
+                Aead::Aes128Gcm => AesGcm128,
+                PublicKey::P384,
+                SenderContext::DhP384HkdfSha384,
+                SenderContextDhP384HkdfSha384::HkdfSha384,
+                SenderContextDhP384HkdfSha384HkdfSha384::AesGcm128,
+            },
+            {
+                Kem::P384Sha384 => DhP384HkdfSha384,
+                Kdf::HkdfSha384 => HkdfSha384,
+                Aead::Aes256Gcm => AesGcm256,
+                PublicKey::P384,
+                SenderContext::DhP384HkdfSha384,
+                SenderContextDhP384HkdfSha384::HkdfSha384,
+                SenderContextDhP384HkdfSha384HkdfSha384::AesGcm256,
+            },
             #[cfg(feature = "pq")]
             {
                 Kem::X25519Kyber768Draft00 => X25519Kyber768Draft00,
@@ -335,6 +392,11 @@ enum ReceiverContextX25519HkdfSha256HkdfSha256 {
     ChaCha20Poly1305(Box<AeadCtxR<ChaCha20Poly1305, HkdfSha256, X25519HkdfSha256>>),
 }
 
+enum ReceiverContextDhP384HkdfSha384HkdfSha384 {
+    AesGcm128(Box<AeadCtxR<AesGcm128, HkdfSha384, DhP384HkdfSha384>>),
+    AesGcm256(Box<AeadCtxR<AesGcm256, HkdfSha384, DhP384HkdfSha384>>),
+}
+
 #[cfg(feature = "pq")]
 enum ReceiverContextX25519Kyber768Draft00HkdfSha256 {
     AesGcm128(Box<AeadCtxR<AesGcm128, HkdfSha256, X25519Kyber768Draft00>>),
@@ -344,6 +406,10 @@ enum ReceiverContextX25519HkdfSha256 {
     HkdfSha256(ReceiverContextX25519HkdfSha256HkdfSha256),
 }
 
+enum ReceiverContextDhP384HkdfSha384 {
+    HkdfSha384(ReceiverContextDhP384HkdfSha384HkdfSha384),
+}
+
 #[cfg(feature = "pq")]
 enum ReceiverContextX25519Kyber768Draft00 {
     HkdfSha256(ReceiverContextX25519Kyber768Draft00HkdfSha256),
@@ -351,6 +417,7 @@ enum ReceiverContextX25519Kyber768Draft00 {
 
 enum ReceiverContext {
     X25519HkdfSha256(ReceiverContextX25519HkdfSha256),
+    DhP384HkdfSha384(ReceiverContextDhP384HkdfSha384),
 
     #[cfg(feature = "pq")]
     X25519Kyber768Draft00(ReceiverContextX25519Kyber768Draft00),
@@ -383,7 +450,30 @@ impl ReceiverContext {
                 context.open_in_place_detached(ct, aad, &tag)?;
                 ct
             }
-
+            Self::DhP384HkdfSha384(ReceiverContextDhP384HkdfSha384::HkdfSha384(
+                ReceiverContextDhP384HkdfSha384HkdfSha384::AesGcm128(context),
+            )) => {
+                if ciphertext.len() < AeadTag::<AesGcm128>::size() {
+                    return Err(Error::Truncated);
+                }
+                let (ct, tag_slice) =
+                    ciphertext.split_at_mut(ciphertext.len() - AeadTag::<AesGcm128>::size());
+                let tag = AeadTag::<AesGcm128>::from_bytes(tag_slice)?;
+                context.open_in_place_detached(ct, aad, &tag)?;
+                ct
+            }
+            Self::DhP384HkdfSha384(ReceiverContextDhP384HkdfSha384::HkdfSha384(
+                ReceiverContextDhP384HkdfSha384HkdfSha384::AesGcm256(context),
+            )) => {
+                if ciphertext.len() < AeadTag::<AesGcm128>::size() {
+                    return Err(Error::Truncated);
+                }
+                let (ct, tag_slice) =
+                    ciphertext.split_at_mut(ciphertext.len() - AeadTag::<AesGcm128>::size());
+                let tag = AeadTag::<AesGcm256>::from_bytes(tag_slice)?;
+                context.open_in_place_detached(ct, aad, &tag)?;
+                ct
+            }
             #[cfg(feature = "pq")]
             Self::X25519Kyber768Draft00(ReceiverContextX25519Kyber768Draft00::HkdfSha256(
                 ReceiverContextX25519Kyber768Draft00HkdfSha256::AesGcm128(context),
@@ -409,6 +499,16 @@ impl ReceiverContext {
             }
             Self::X25519HkdfSha256(ReceiverContextX25519HkdfSha256::HkdfSha256(
                 ReceiverContextX25519HkdfSha256HkdfSha256::ChaCha20Poly1305(context),
+            )) => {
+                context.export(info, out_buf)?;
+            }
+            Self::DhP384HkdfSha384(ReceiverContextDhP384HkdfSha384::HkdfSha384(
+                ReceiverContextDhP384HkdfSha384HkdfSha384::AesGcm128(context),
+            )) => {
+                context.export(info, out_buf)?;
+            }
+            Self::DhP384HkdfSha384(ReceiverContextDhP384HkdfSha384::HkdfSha384(
+                ReceiverContextDhP384HkdfSha384HkdfSha384::AesGcm256(context),
             )) => {
                 context.export(info, out_buf)?;
             }
@@ -493,6 +593,24 @@ impl HpkeR {
                 ReceiverContextX25519HkdfSha256::HkdfSha256,
                 ReceiverContextX25519HkdfSha256HkdfSha256::ChaCha20Poly1305,
             },
+            {
+                Kem::P384Sha384 => DhP384HkdfSha384,
+                Kdf::HkdfSha384 => HkdfSha384,
+                Aead::Aes128Gcm => AesGcm128,
+                PrivateKey::P384,
+                ReceiverContext::DhP384HkdfSha384,
+                ReceiverContextDhP384HkdfSha384::HkdfSha384,
+                ReceiverContextDhP384HkdfSha384HkdfSha384::AesGcm128,
+            },
+            {
+                Kem::P384Sha384 => DhP384HkdfSha384,
+                Kdf::HkdfSha384 => HkdfSha384,
+                Aead::Aes256Gcm => AesGcm256,
+                PrivateKey::P384,
+                ReceiverContext::DhP384HkdfSha384,
+                ReceiverContextDhP384HkdfSha384::HkdfSha384,
+                ReceiverContextDhP384HkdfSha384HkdfSha384::AesGcm256,
+            },
 
             #[cfg(feature = "pq")]
             {
@@ -515,6 +633,10 @@ impl HpkeR {
 
     pub fn decode_public_key(kem: Kem, k: &[u8]) -> Res<PublicKey> {
         Ok(match kem {
+            Kem::P384Sha384 => {
+                PublicKey::P384(<DhP384HkdfSha384 as KemTrait>::PublicKey::from_bytes(k)?)
+            }
+
             Kem::X25519Sha256 => {
                 PublicKey::X25519(<X25519HkdfSha256 as KemTrait>::PublicKey::from_bytes(k)?)
             }
@@ -554,6 +676,11 @@ impl Deref for HpkeR {
 pub fn generate_key_pair(kem: Kem) -> Res<(PrivateKey, PublicKey)> {
     let mut csprng = thread_rng();
     let (sk, pk) = match kem {
+        Kem::P384Sha384 => {
+            let (sk, pk) = DhP384HkdfSha384::gen_keypair(&mut csprng);
+            (PrivateKey::P384(sk), PublicKey::P384(pk))
+        }
+
         Kem::X25519Sha256 => {
             let (sk, pk) = X25519HkdfSha256::gen_keypair(&mut csprng);
             (PrivateKey::X25519(sk), PublicKey::X25519(pk))
@@ -575,6 +702,11 @@ pub fn generate_key_pair(kem: Kem) -> Res<(PrivateKey, PublicKey)> {
 #[allow(clippy::unnecessary_wraps)]
 pub fn derive_key_pair(kem: Kem, ikm: &[u8]) -> Res<(PrivateKey, PublicKey)> {
     let (sk, pk) = match kem {
+        Kem::P384Sha384 => {
+            let (sk, pk) = DhP384HkdfSha384::derive_keypair(ikm);
+            (PrivateKey::P384(sk), PublicKey::P384(pk))
+        }
+
         Kem::X25519Sha256 => {
             let (sk, pk) = X25519HkdfSha256::derive_keypair(ikm);
             (PrivateKey::X25519(sk), PublicKey::X25519(pk))


### PR DESCRIPTION
This PR adds support for chunked oblivious response processing and keying based on P384/HKDFSHA384. It also removes asserts and panics, replacing them with errors. 